### PR TITLE
Use `File::create` to ensure file is truncated

### DIFF
--- a/src/mo_file/mo_file_writer.rs
+++ b/src/mo_file/mo_file_writer.rs
@@ -1,7 +1,7 @@
 //! Write MO files.
 
 use std::{
-    fs::OpenOptions,
+    fs::File,
     io::{BufWriter, Write},
     path::Path,
 };
@@ -106,12 +106,7 @@ fn sorted_message_indices(catalog: &Catalog) -> Vec<usize> {
 
 /// Saves a catalog to a binary MO file.
 pub fn write(catalog: &Catalog, path: &Path) -> Result<(), std::io::Error> {
-    let file = OpenOptions::new()
-        .write(true)
-        .create(true)
-        .append(false)
-        .open(path)?;
-
+    let file = File::create(path)?;
     let mut writer = BufWriter::new(file);
 
     let indices = sorted_message_indices(catalog);

--- a/src/po_file/po_file_writer.rs
+++ b/src/po_file/po_file_writer.rs
@@ -2,7 +2,7 @@
 
 use super::escape::escape;
 use crate::catalog::Catalog;
-use std::fs::OpenOptions;
+use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::path::Path;
 
@@ -101,12 +101,7 @@ fn write_field(
 
 /// Saves a catalog to a PO file on the disk.
 pub fn write(catalog: &Catalog, path: &Path) -> Result<(), std::io::Error> {
-    let file = OpenOptions::new()
-        .read(false)
-        .write(true)
-        .create(true)
-        .append(false)
-        .open(path)?;
+    let file = File::create(path)?;
     let mut writer = BufWriter::new(file);
     writer.write_all(b"\nmsgid \"\"\n")?;
     write_field(&mut writer, "msgstr", catalog.metadata.dump().as_str())?;


### PR DESCRIPTION
Before, the code used `OpenOptions` with a number of flags. However, the `truncate` option was not set, so the new data would be appended to existing files.

Using `File::create` instead ensures that an existing file is truncated.

I noticed this problem when using `polib` in Comprehensive Rust where I extract strings from Markdown files: [`mdbook-xgettext`](https://github.com/google/comprehensive-rust/blob/main/i18n-helpers/src/bin/mdbook-xgettext.rs#L119).