### PR TITLE
Add parse_from_reader

### DIFF
--- a/src/po_file/mod.rs
+++ b/src/po_file/mod.rs
@@ -3,6 +3,8 @@
 mod escape;
 mod po_file_parser;
 mod po_file_writer;
-pub use po_file_parser::{parse, parse_with_option};
+pub use po_file_parser::{
+    parse, parse_from_reader, parse_from_reader_with_option, parse_with_option,
+};
 pub use po_file_parser::{POParseError, POParseOptions};
 pub use po_file_writer::write;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -7,3 +7,11 @@ fn parse_sample_po() {
     let catalog = po_file::parse(path).unwrap();
     assert!(catalog.count() > 0);
 }
+
+#[test]
+fn parse_sample_po_str() {
+    let path = Path::new("./tests/sample.po");
+    let text = std::fs::read_to_string(path).unwrap();
+    let catalog = po_file::parse_from_reader(text.as_bytes()).unwrap();
+    assert!(catalog.count() > 0);
+}


### PR DESCRIPTION
I'm considering using `polib` for simple translations instead of `gettext`. I've added functionality to read from `io::Read` to parse PO files included during compilation using `include_str!`. I would appreciate it if you could consider merging this pull request. Thank you very much.