### PR TITLE
Derive or implement standard traits where possible

### DIFF
--- a/src/catalog/iterator.rs
+++ b/src/catalog/iterator.rs
@@ -5,6 +5,7 @@ use crate::message::{
     CatalogMessageMutView, Message, MessageFlags, MessageKey, MessageMutView, MessageView,
     SingularPluralMismatchError,
 };
+use std::fmt::{self, Debug, Formatter};
 
 pub struct CatalogMessageRef<C> {
     catalog: C,
@@ -91,6 +92,12 @@ impl<'a> MessageMutProxy<'a> {
 
     fn message_mut(&mut self) -> &mut Message {
         self.0.catalog.messages[self.0.index].as_mut().unwrap()
+    }
+}
+
+impl<'a> Debug for MessageMutProxy<'a> {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        self.message().fmt(f)
     }
 }
 

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -10,6 +10,7 @@ pub use iterator::{Iter, IterMut, MessageMutProxy};
 use std::collections::btree_map::BTreeMap;
 
 /// `Catalog` struct represents a collection of _Messages_ stored in a `.po` or `.mo` file.
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Catalog {
     /// Metadata of the catalog.
     pub metadata: CatalogMetadata,

--- a/src/message/builder.rs
+++ b/src/message/builder.rs
@@ -1,6 +1,7 @@
 use crate::message::{Message, MessageFlags};
 
 /// A helper type to build a `Message` conveniently via method chaining.
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MessageBuilder {
     m: Message,
 }

--- a/src/message/flags.rs
+++ b/src/message/flags.rs
@@ -4,7 +4,7 @@ use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 
 /// Represents the set of flags in a message
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MessageFlags {
     /// Vector of individual flags
     pub entries: Vec<String>,

--- a/src/message/key.rs
+++ b/src/message/key.rs
@@ -3,7 +3,7 @@
 use crate::message::{Message, MessageView};
 use concat_string::concat_string;
 
-#[derive(PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub(crate) struct MessageKey {
     key: String,
 }

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -11,7 +11,7 @@ pub(crate) use key::MessageKey;
 pub use view::{CatalogMessageMutView, MessageMutView, MessageView, SingularPluralMismatchError};
 
 /// Represents a single message entry.
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct Message {
     /// Developer comments of the message.
     pub(crate) comments: String,

--- a/src/message/view.rs
+++ b/src/message/view.rs
@@ -7,7 +7,7 @@ use std::fmt::{Display, Formatter};
 use crate::message::{Message, MessageFlags};
 
 /// Error type when trying to access a field that is not applicable to the plural type of the message.
-#[derive(Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SingularPluralMismatchError;
 
 impl Display for SingularPluralMismatchError {

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use crate::plural::*;
 
 /// Metadata of a translation catalog.
-#[derive(Default)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct CatalogMetadata {
     /// `Project-Id-Version`
     pub project_id_version: String,
@@ -30,7 +30,7 @@ pub struct CatalogMetadata {
 }
 
 /// Error in parsing metadata of a catalog
-#[derive(Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MetadataParseError {
     message: String,
 }

--- a/src/plural.rs
+++ b/src/plural.rs
@@ -1,4 +1,5 @@
 /// The plural form resolution rule of the target language.
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CatalogPluralRules {
     /// Total number of plural forms, including singular form.
     pub nplurals: usize,
@@ -16,7 +17,7 @@ impl Default for CatalogPluralRules {
 }
 
 /// Error type when parsing an invalid plural rules.
-#[derive(Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PluralRulesError {
     message: String,
 }

--- a/src/po_file/po_file_parser.rs
+++ b/src/po_file/po_file_parser.rs
@@ -13,7 +13,7 @@ use std::path::Path;
 use std::str::{FromStr, Utf8Error};
 
 /// PO file parse options.
-#[derive(Clone, Copy, Default)]
+#[derive(Copy, Clone, Default, Eq, PartialEq)]
 pub struct POParseOptions {
     /// If true, only parse msgctxt, msgid and msgstr.
     pub message_body_only: bool,
@@ -31,7 +31,7 @@ impl POParseOptions {
 }
 
 /// Error in parsing a PO file
-#[derive(Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct POParseError {
     message: String,
 }


### PR DESCRIPTION
`Debug` is useful for debug printing various values along the way, `Eq` is useful for tests, and `Clone` is useful all over the place. This should make life easier for users of the library.