### PR TITLE
Require Debug for MessageView.

### DIFF
--- a/src/message/view.rs
+++ b/src/message/view.rs
@@ -2,7 +2,7 @@
 
 use std::borrow::{Borrow, ToOwned};
 use std::error::Error;
-use std::fmt::{Display, Formatter};
+use std::fmt::{Debug, Display, Formatter};
 
 use crate::message::{Message, MessageFlags};
 
@@ -19,7 +19,7 @@ impl Display for SingularPluralMismatchError {
 impl Error for SingularPluralMismatchError {}
 
 /// Immutable view of a `Message`.
-pub trait MessageView {
+pub trait MessageView: Debug {
     /// Is this message singular?
     fn is_singular(&self) -> bool;
 


### PR DESCRIPTION
This is technically a breaking change, as a client could have implemented this trait for some reason.

It is useful because it allows the items of `catalog::Iter` to be debug printed.