### PR TITLE
Add default Plural-Forms

### DIFF
--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -87,7 +87,11 @@ impl CatalogMetadata {
                 .unwrap_or(&"")
                 .to_string(),
             language: key_values.get("Language").unwrap_or(&"").to_string(),
-            plural_rules: CatalogPluralRules::parse(key_values.get("Plural-Forms").unwrap_or(&""))?,
+            plural_rules: CatalogPluralRules::parse(
+                key_values
+                    .get("Plural-Forms")
+                    .unwrap_or(&"nplurals=1; plural=0;"),
+            )?,
         };
         Ok(res)
     }


### PR DESCRIPTION
A PO provider generates PO files without `Plural-Forms` field if the PO file doesn't have the actual `msgplural` entries.
In the current implementation, if there is not `Plural-Forms` field, `plural_rules` becomes `""` and failed at `CatalogPluralRules::parse`.

So this PR sets `nplurals=1; plural=0;` as the default value of `Plural-Forms`.