### PR TITLE
Add support for translator comments & metadata header

### DIFF
--- a/src/catalog/iterator.rs
+++ b/src/catalog/iterator.rs
@@ -118,8 +118,12 @@ impl<'a> MessageView for MessageMutProxy<'a> {
         self.message().is_fuzzy()
     }
 
-    fn comments(&self) -> &str {
-        self.message().comments()
+    fn translator_comments(&self) -> &str {
+        self.message().translator_comments()
+    }
+
+    fn extracted_comments(&self) -> &str {
+        self.message().extracted_comments()
     }
 
     fn source(&self) -> &str {
@@ -152,8 +156,12 @@ impl<'a> MessageView for MessageMutProxy<'a> {
 }
 
 impl<'a> MessageMutView for MessageMutProxy<'a> {
-    fn comments_mut(&mut self) -> &mut String {
-        &mut self.message_mut().comments
+    fn translator_comments_mut(&mut self) -> &mut String {
+        &mut self.message_mut().translator_comments
+    }
+
+    fn extracted_comments_mut(&mut self) -> &mut String {
+        &mut self.message_mut().extracted_comments
     }
 
     fn source_mut(&mut self) -> &mut String {

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -12,6 +12,8 @@ use std::collections::btree_map::BTreeMap;
 /// `Catalog` struct represents a collection of _Messages_ stored in a `.po` or `.mo` file.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Catalog {
+    /// Pre-header section often containing translation contributors
+    pub preheader: Vec<String>,
     /// Metadata of the catalog.
     pub metadata: CatalogMetadata,
     pub(crate) messages: Vec<Option<Message>>,
@@ -21,6 +23,7 @@ pub struct Catalog {
 impl Catalog {
     pub(crate) fn empty() -> Self {
         Self {
+            preheader: vec![],
             metadata: CatalogMetadata::default(),
             messages: vec![],
             map: BTreeMap::new(),

--- a/src/message/builder.rs
+++ b/src/message/builder.rs
@@ -29,9 +29,15 @@ impl Message {
 }
 
 impl MessageBuilder {
-    /// Set the comments field.
-    pub fn with_comments(&mut self, comments: String) -> &mut Self {
-        self.m.comments = comments;
+    /// Set the translator comments field.
+    pub fn with_translator_comments(&mut self, comments: String) -> &mut Self {
+        self.m.translator_comments = comments;
+        self
+    }
+
+    /// Set the extracted comments field.
+    pub fn with_extracted_comments(&mut self, comments: String) -> &mut Self {
+        self.m.extracted_comments = comments;
         self
     }
 

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -13,8 +13,10 @@ pub use view::{CatalogMessageMutView, MessageMutView, MessageView, SingularPlura
 /// Represents a single message entry.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct Message {
+    /// Translator comments of the message.
+    pub(crate) translator_comments: String,
     /// Developer comments of the message.
-    pub(crate) comments: String,
+    pub(crate) extracted_comments: String,
     /// Source code location of the message.
     pub(crate) source: String,
     /// Flags of the message.

--- a/src/message/view.rs
+++ b/src/message/view.rs
@@ -32,8 +32,11 @@ pub trait MessageView: Debug {
     /// Is this message fuzzy?
     fn is_fuzzy(&self) -> bool;
 
-    /// Get comments field of the message.
-    fn comments(&self) -> &str;
+    /// Get translator comments field of the message.
+    fn translator_comments(&self) -> &str;
+
+    /// Get extracted comments field of the message.
+    fn extracted_comments(&self) -> &str;
 
     /// Get source code location field of the message.
     fn source(&self) -> &str;
@@ -59,8 +62,11 @@ pub trait MessageView: Debug {
 
 /// Mutable view of a `Message`.
 pub trait MessageMutView: MessageView {
-    /// Get a mutable reference to the comments field of the message.
-    fn comments_mut(&mut self) -> &mut String;
+    /// Get a mutable reference to the translator comments field of the message.
+    fn translator_comments_mut(&mut self) -> &mut String;
+
+    /// Get a mutable reference to the extracted comments field of the message.
+    fn extracted_comments_mut(&mut self) -> &mut String;
 
     /// Get a mutable reference to the source code location field of the message.
     fn source_mut(&mut self) -> &mut String;
@@ -120,8 +126,12 @@ impl MessageView for Message {
         self.flags.is_fuzzy()
     }
 
-    fn comments(&self) -> &str {
-        &self.comments
+    fn translator_comments(&self) -> &str {
+        &self.translator_comments
+    }
+
+    fn extracted_comments(&self) -> &str {
+        &self.extracted_comments
     }
 
     fn source(&self) -> &str {
@@ -170,8 +180,12 @@ impl MessageView for Message {
 }
 
 impl MessageMutView for Message {
-    fn comments_mut(&mut self) -> &mut String {
-        &mut self.comments
+    fn translator_comments_mut(&mut self) -> &mut String {
+        &mut self.translator_comments
+    }
+
+    fn extracted_comments_mut(&mut self) -> &mut String {
+        &mut self.extracted_comments
     }
 
     fn source_mut(&mut self) -> &mut String {
@@ -240,7 +254,8 @@ impl ToOwned for dyn MessageView {
     fn to_owned(&self) -> Self::Owned {
         if self.is_singular() {
             Self::Owned {
-                comments: self.comments().to_string(),
+                translator_comments: self.translator_comments().to_string(),
+                extracted_comments: self.extracted_comments().to_string(),
                 source: self.source().to_string(),
                 flags: self.flags().clone(),
                 msgctxt: self.msgctxt().unwrap_or("").to_string(),
@@ -252,7 +267,8 @@ impl ToOwned for dyn MessageView {
             }
         } else {
             Self::Owned {
-                comments: self.comments().to_string(),
+                translator_comments: self.translator_comments().to_string(),
+                extracted_comments: self.extracted_comments().to_string(),
                 source: self.source().to_string(),
                 flags: self.flags().clone(),
                 msgctxt: self.msgctxt().unwrap_or("").to_string(),

--- a/src/po_file/po_file_parser.rs
+++ b/src/po_file/po_file_parser.rs
@@ -189,8 +189,10 @@ impl POParserState {
         let mut po_message = std::mem::take(&mut self.current_message);
         if !self.metadata_parsed {
             if po_message.msgid.is_empty() && !po_message.msgstr.is_empty() {
-                for line in po_message.translator_comments.split("\n") {
-                    self.catalog.preheader.push(line.to_string());
+                if !po_message.translator_comments.is_empty() {
+                    for line in po_message.translator_comments.split("\n") {
+                        self.catalog.preheader.push(line.to_string());
+                    }
                 }
                 let unescaped = unescape(&po_message.msgstr)?;
                 self.catalog.metadata = CatalogMetadata::parse(&unescaped)?;

--- a/src/po_file/po_file_parser.rs
+++ b/src/po_file/po_file_parser.rs
@@ -189,6 +189,9 @@ impl POParserState {
         let mut po_message = std::mem::take(&mut self.current_message);
         if !self.metadata_parsed {
             if po_message.msgid.is_empty() && !po_message.msgstr.is_empty() {
+                for line in po_message.translator_comments.split("\n") {
+                    self.catalog.preheader.push(line.to_string());
+                }
                 let unescaped = unescape(&po_message.msgstr)?;
                 self.catalog.metadata = CatalogMetadata::parse(&unescaped)?;
                 self.metadata_parsed = true;

--- a/src/po_file/po_file_writer.rs
+++ b/src/po_file/po_file_writer.rs
@@ -119,8 +119,15 @@ fn write_internal<W: Write>(
     };
 
     for message in messages {
-        if !message.comments().is_empty() {
-            for line in message.comments().split('\n') {
+        if !message.translator_comments().is_empty() {
+            for line in message.translator_comments().split('\n') {
+                writer.write_all(b"# ")?;
+                writer.write_all(line.as_bytes())?;
+                writer.write_all(b"\n")?;
+            }
+        }
+        if !message.extracted_comments().is_empty() {
+            for line in message.extracted_comments().split('\n') {
                 writer.write_all(b"#. ")?;
                 writer.write_all(line.as_bytes())?;
                 writer.write_all(b"\n")?;


### PR DESCRIPTION
This PR adds support for translator comments which are part of the [PO file format](https://www.gnu.org/software/gettext/manual/html_node/PO-Files.html).

I named the new properties `translator_comments` and `extracted_comments` to match the gettext's name, but feel free to propose something else.

Additionnaly, special translator comments can be used with metadata description to list translators, project's license, etc., for example:

```
# SOME DESCRIPTIVE TITLE.
# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
# This file is distributed under the same license as the PACKAGE package.
# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
# Author 1 <mail1>, 2019-2024.
# Author 2 <mail2>, 2022-2025.
# Author 3 <mail2>, 2024.
#
msgid ""
msgstr ""
"Project-Id-Version: module\n"
```

I didn't see the point in creating a dedicated `CatalogPreheader` structure to hold the `String` vector, although that could be possible.